### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,9 @@ rvm:
   - 2.1
   - 2.2
   - 2.3
-  - 2.4
+  - 2.4.1
+  - ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true


### PR DESCRIPTION
Hello @tenderlove 

I want to start Travis CI test in this repository.

Can you activate below Travis for thie repo?
https://travis-ci.org/tenderlove/builder

"2.4" might not have been available yet.
https://github.com/travis-ci/travis-ci/issues/7077

Adding `ruby-head` as `allow_failures` is a good practice to see the result of the new version Ruby, as faster, and prepare for that.

Thanks.
