### PR TITLE
Option to create CDATA values, not just elements

### DIFF
--- a/lib/builder/xmlmarkup.rb
+++ b/lib/builder/xmlmarkup.rb
@@ -271,6 +271,12 @@ module Builder
       _special("<![CDATA[", "]]>", text.gsub(']]>', ']]]]><![CDATA[>'), nil)
     end
 
+    def cdata_value!(open, close, text)
+      _ensure_no_block ::Kernel::block_given?
+      _special(open, close, "<![CDATA[#{text.gsub(']]>', ']]]]><![CDATA[>')}]]>", nil)
+    end
+
+
     private
 
     # NOTE: All private methods of a builder object are prefixed when

--- a/lib/builder/xmlmarkup.rb
+++ b/lib/builder/xmlmarkup.rb
@@ -271,11 +271,10 @@ module Builder
       _special("<![CDATA[", "]]>", text.gsub(']]>', ']]]]><![CDATA[>'), nil)
     end
 
-    def cdata_value!(open, close, text)
+    def cdata_value!(open, text)
       _ensure_no_block ::Kernel::block_given?
-      _special(open, close, "<![CDATA[#{text.gsub(']]>', ']]]]><![CDATA[>')}]]>", nil)
+      _special("<#{open}>", "</#{open}>", "<![CDATA[#{text.gsub(']]>', ']]]]><![CDATA[>')}]]>", nil)
     end
-
 
     private
 

--- a/test/test_markupbuilder.rb
+++ b/test/test_markupbuilder.rb
@@ -417,6 +417,11 @@ class TestSpecialMarkup < Builder::Test
     assert_equal "<![CDATA[TEST]]>\n", @xml.target!
   end
 
+  def test_cdata_value
+    @xml.cdata_value!("content:encoded", "<p>TEST</p>")
+    assert_equal "<content:encoded><![CDATA[<p>TEST</p>]]></content:encoded>\n", @xml.target!
+  end
+
   def test_cdata_with_ampersand
     @xml.cdata!("TEST&CHECK")
     assert_equal "<![CDATA[TEST&CHECK]]>\n", @xml.target!


### PR DESCRIPTION
Wanting to create an RSS feed in rails for facebook https://developers.facebook.com/docs/instant-articles/publishing/setup-rss-feed/

The `content:encoded` tag requires the value to be encapsulated in CDATA tags.  I couldn't find a way of doing this in builder and so added a new method.