### PR TITLE
Updates for frozen string literal compatibility.

### DIFF
--- a/lib/builder/xmlbase.rb
+++ b/lib/builder/xmlbase.rb
@@ -52,7 +52,7 @@ module Builder
           attrs ||= {}
           attrs.merge!({:nil => true}) if explicit_nil_handling?
         else
-          text ||= ''
+          text ||= ''.dup
           text << arg.to_s
         end
       end

--- a/lib/builder/xmlmarkup.rb
+++ b/lib/builder/xmlmarkup.rb
@@ -192,7 +192,7 @@ module Builder
       @quote = (options[:quote] == :single) ? "'" : '"'
       @explicit_nil_handling = options[:explicit_nil_handling]
       super(indent, margin)
-      @target = options[:target] || ""
+      @target = options[:target] || "".dup
     end
 
     # Return the target of the builder.

--- a/test/test_markupbuilder.rb
+++ b/test/test_markupbuilder.rb
@@ -499,7 +499,7 @@ class TestIndentedXmlMarkup < Builder::Test
         $KCODE = encoding
         string
       elsif encoding == 'UTF8'
-        string.force_encoding('UTF-8')
+        string.dup.force_encoding('UTF-8')
       else
         string
       end
@@ -580,7 +580,7 @@ class TestIndentedXmlMarkup < Builder::Test
     end
 
     def pop_text
-      result = ''
+      result = ''.dup
       while ! @handler.events.empty? && @handler.events[0][0] == :text
 	result << @handler.events[0][1]
 	@handler.events.shift

--- a/test/test_xchar.rb
+++ b/test/test_xchar.rb
@@ -24,7 +24,7 @@ if String.method_defined?(:encode)
     def to_xs(escape=true)
       raise NameError.new('to_xs') unless caller[0].index(__FILE__)
 
-      result = Builder::XChar.encode(self)
+      result = Builder::XChar.encode(self.dup)
       if escape
         result.gsub(/[^\u0000-\u007F]/) {|c| "&##{c.ord};"}
       else


### PR DESCRIPTION
These changes allow the test suite to pass with `RUBYOPT="--enable-frozen-string-literal"`.

If you wanted, you can update `.travis.yml` to include the following, which automatically enables that flag against MRI 2.4.1 (thus picking up regressions). It'd be nice if it worked reliably for future MRI releases and ruby-head though (I'll ponder a better way of doing this that covers those scenarios).

```yml
before_script:
- ((ruby --version | grep -q "2.4.1") && export RUBYOPT="--enable-frozen-string-literal") || true
```