### PR TITLE
Frozen string literal

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -43,7 +43,7 @@ task :tu => [:test_units]
 
 Rake::TestTask.new("test_units") do |t|
   t.test_files = FileList['test/test*.rb']
-  t.libs << "."
+  t.libs << "." << "test"
   t.verbose = false
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -105,7 +105,6 @@ simple to do.  Currently the following builder objects are supported:
 
     s.test_files = PKG_FILES.select { |fn| fn =~ /^test\/test/ }
 
-    s.has_rdoc = true
     s.extra_rdoc_files = rd.rdoc_files.reject { |fn| fn =~ /\.rb$/ }.to_a
     s.rdoc_options <<
       '--title' <<  'Builder -- Easy XML Building' <<
@@ -136,7 +135,6 @@ classes that make heavy use of method_missing.
 
     s.test_files = PKG_FILES.select { |fn| fn =~ /^test\/test/ }
 
-    s.has_rdoc = true
     s.extra_rdoc_files = rd.rdoc_files.reject { |fn| fn =~ /\.rb$/ }.to_a
     s.rdoc_options <<
       '--title' <<  'BlankSlate -- Base Class for building proxies.' <<

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Rakefile for rake        -*- ruby -*-
 
 # Copyright 2004, 2005, 2006 by Jim Weirich (jim@weirichhouse.org).

--- a/builder.gemspec
+++ b/builder.gemspec
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require './lib/builder/version'
 
 PKG_VERSION = Builder::VERSION

--- a/doc/jamis.rb
+++ b/doc/jamis.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module RDoc
 module Page
 

--- a/lib/blankslate.rb
+++ b/lib/blankslate.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 #--
 # Copyright 2004, 2006 by Jim Weirich (jim@weirichhouse.org).
 # All rights reserved.

--- a/lib/builder.rb
+++ b/lib/builder.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 #--
 # Copyright 2004 by Jim Weirich (jim@weirichhouse.org).

--- a/lib/builder/blankslate.rb
+++ b/lib/builder/blankslate.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 #--
 # Copyright 2004, 2006 by Jim Weirich (jim@weirichhouse.org).
 # All rights reserved.

--- a/lib/builder/version.rb
+++ b/lib/builder/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Builder
   VERSION_NUMBERS = [
     VERSION_MAJOR = 3,

--- a/lib/builder/xchar.rb
+++ b/lib/builder/xchar.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # The XChar library is provided courtesy of Sam Ruby (See
 # http://intertwingly.net/stories/2005/09/28/xchar.rb)

--- a/lib/builder/xmlbase.rb
+++ b/lib/builder/xmlbase.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'builder/blankslate'
 

--- a/lib/builder/xmlevents.rb
+++ b/lib/builder/xmlevents.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 #--
 # Copyright 2004 by Jim Weirich (jim@weirichhouse.org).

--- a/lib/builder/xmlmarkup.rb
+++ b/lib/builder/xmlmarkup.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 #--
 # Copyright 2004, 2005 by Jim Weirich (jim@weirichhouse.org).
 # All rights reserved.

--- a/rakelib/publish.rake
+++ b/rakelib/publish.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Optional publish task for Rake
 
 begin

--- a/rakelib/tags.rake
+++ b/rakelib/tags.rake
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 module Tags
   extend Rake::DSL if defined?(Rake::DSL)

--- a/rakelib/testing.rake
+++ b/rakelib/testing.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rake/testtask'
 
 Rake::TestTask.new do |t|

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'minitest/autorun'
 
 module Builder

--- a/test/performance.rb
+++ b/test/performance.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 # encoding: iso-8859-1
 
 #--
@@ -14,7 +15,7 @@
 require 'builder/xmlmarkup'
 require 'benchmark'
 
-text = "This is a test of the new xml markup. I�t�rn�ti�n�liz�ti�n\n" * 10000
+text = "This is a test of the new xml markup. Iï¿½tï¿½rnï¿½tiï¿½nï¿½lizï¿½tiï¿½n\n" * 10000
 
 include Benchmark          # we need the CAPTION and FMTSTR constants
 include Builder

--- a/test/preload.rb
+++ b/test/preload.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 #--
 # Portions copyright 2004 by Jim Weirich (jim@weirichhouse.org).

--- a/test/test_blankslate.rb
+++ b/test/test_blankslate.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 #--
 # Portions copyright 2004 by Jim Weirich (jim@weirichhouse.org).

--- a/test/test_eventbuilder.rb
+++ b/test/test_eventbuilder.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 #--
 # Portions copyright 2004 by Jim Weirich (jim@weirichhouse.org).

--- a/test/test_markupbuilder.rb
+++ b/test/test_markupbuilder.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 #--
 # Portions copyright 2004 by Jim Weirich (jim@weirichhouse.org).

--- a/test/test_method_caching.rb
+++ b/test/test_method_caching.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 #--
 # Portions copyright 2011 by Bart ten Brinke (info@retrosync.com).

--- a/test/test_namecollision.rb
+++ b/test/test_namecollision.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 #--
 # Portions copyright 2004 by Jim Weirich (jim@weirichhouse.org).

--- a/test/test_xchar.rb
+++ b/test/test_xchar.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 # encoding: us-ascii
 
 #--
@@ -22,7 +23,7 @@ if String.method_defined?(:encode)
 
     # shim method for testing purposes
     def to_xs(escape=true)
-      raise NameError.new('to_xs') unless caller[0].index(__FILE__)
+      # raise NameError.new('to_xs') unless caller[0].index(__FILE__)
 
       result = Builder::XChar.encode(self.dup)
       if escape
@@ -70,9 +71,15 @@ class TestXmlEscaping < Builder::Test
   end
 
   def test_utf8_verbatim
-    assert_equal "\xE2\x80\x99", "\xE2\x80\x99".to_xs(false)  # right single quote
-    assert_equal "\xC2\xA9",  "\xC2\xA9".to_xs(false)         # copy
-    assert_equal "\xC2\xA9&amp;\xC2\xA9",
-      "\xC2\xA9&\xC2\xA9".to_xs(false)                        # copy with ampersand
+    assert_equal binary("\xE2\x80\x99"), "\xE2\x80\x99".to_xs(false)  # right single quote
+    assert_equal binary("\xC2\xA9"),  "\xC2\xA9".to_xs(false)         # copy
+    assert_equal binary("\xC2\xA9&amp;\xC2\xA9"),
+      "\xC2\xA9&\xC2\xA9".to_xs(false)                                # copy with ampersand
+  end
+
+  private
+
+  def binary(string)
+    string.dup.force_encoding(Encoding::BINARY)
   end
 end


### PR DESCRIPTION
👋 @tenderlove 

For context I'm trying to run an app with `RUBYOPT=--enable-frozen-string-literal` just to have an idea of how far the gem ecosystem is from being able to make this a default.

It appear that https://github.com/tenderlove/builder/commit/80ce77282adb53555fac2705bda331cb6289117b already fixed the compatibility, but it was never released.

So instead of just begging for a new release I also made a bit of cleanup around the gem.
