### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/builder.gemspec
+++ b/builder.gemspec
@@ -42,4 +42,11 @@ simple to do.  Currently the following builder objects are supported:
   s.email = "aron.patterson@gmail.com"
   s.homepage = "https://github.com/tenderlove/builder"
   s.license = 'MIT'
+  s.metadata = {
+    "bug_tracker_uri"   => "#{s.homepage}/issues",
+    "changelog_uri"     => "#{s.homepage}/blob/master/CHANGES",
+    "documentation_uri" => "https://www.rubydoc.info/gems/builder/#{s.version}",
+    "homepage_uri"      => s.homepage,
+    "source_code_uri"   => "#{s.homepage}/tree/v#{s.version}"
+  }
 end


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `homepage_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/builder), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.